### PR TITLE
Fix dt field to produce UTC timestamps instead of local

### DIFF
--- a/tests/test_log_entry.py
+++ b/tests/test_log_entry.py
@@ -1,0 +1,14 @@
+# coding: utf-8
+
+from timber.log_entry import create_log_entry
+from timber.handler import TimberHandler
+import unittest2
+import logging
+
+class TestTimberLogEntry(unittest2.TestCase):
+    def test_create_log_entry(self):
+        handler = TimberHandler(api_key="some-api-key")
+        log_record = logging.LogRecord("timber-test", 20, "/some/path", 10, "Some log message", [], None)
+        log_entry = create_log_entry(handler, log_record)
+        self.assertTrue(log_entry['level'] == 'info')
+

--- a/timber/log_entry.py
+++ b/timber/log_entry.py
@@ -12,7 +12,7 @@ def create_log_entry(handler, record):
     r = record.__dict__
     entry = {}
     entry['$schema'] = SCHEMA_URL
-    entry['dt'] = datetime.fromtimestamp(r['created']).isoformat()
+    entry['dt'] = datetime.utcfromtimestamp(r['created']).isoformat()
     entry['level'] = level = _levelname(r['levelname'])
     entry['severity'] = int(r['levelno'] / 10)
     entry['message'] = handler.format(record)


### PR DESCRIPTION
This change ensures that the timestamp produced from translating the
`LogRecord` created field to ISO8601 is using UTC time instead of
localtime to conform to the rest of the log producing libraries from
timber.