### PR TITLE
Update for Timber 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,171 +1,45 @@
-# Timber - Master your Python app with structured logging
+# 🌲 Timber - Great Python Logging Made Easy
 
-Timber for Python is a `logging` handler that sends your log statements to [Timber](https://timber.io), making them [easier to search, use, and read](https://github.com/timberio/timber-ruby#get-things-done-with-your-logs). In particular, `timber` makes it easier to add [metadata and context](https://timber.io/docs/concepts/metadata-context-and-events) to your log statements.
+<p align="center">
+  <a href="https://timber.io" target="_blank" align="center">
+    <img src="https://res.cloudinary.com/timber/image/upload/v1552328675/banner.jpg" width="900">
+  </a>
+  <br>
+</p>
 
-Interested in learning more? Check out [our docs](https://docs.timber.io/languages/python/).
+[![ISC License](https://img.shields.io/badge/license-ISC-ff69b4.svg)](LICENSE.md)
+[![Pypi](https://img.shields.io/pypi/v/timber.svg)](https://pypi.python.org/pypi/timber)
+[![Python Support](https://img.shields.io/pypi/pyversions/timber.svg)](https://pypi.python.org/pypi/django-analytical)
+[![Build Status](https://travis-ci.org/timberio/timber-python.svg?branch=master)](https://travis-ci.org/timberio/timber-python)
 
-:point_right: **Timber python is under development and is in beta testing.**
+[Timber.io](https://timber.io) is a hosted service for aggregating logs across your entire stack -
+[any language](https://docs.timber.io/setup/languages),
+[any platform](https://docs.timber.io/setup/platforms),
+[any data source](https://docs.timber.io/setup/log_forwarders).
 
-# Installation
+Unlike traditional logging tools, Timber integrates with language runtimes to automatically
+capture in-app context, turning your text-based logs into rich structured events.
+Timber integrates with Python through this library. And Timber's
+[rich free-form query tools](https://docs-new.timber.io/usage/live-tailing#query-syntax) and
+[real-time tailing](https://docs-new.timber.io/usage/live-tailing), make drilling down into
+important stats easier than ever.
 
-To install the library and get started logging to Timber:
+---
 
-```bash
-pip install timber
-```
+* **[Features](https://docs.timber.io/setup/languages/python#features)**
+* **[Installation](https://docs.timber.io/setup/languages/python#installation)**
+* **[Configuration](https://docs.timber.io/setup/languages/python#configuration)**
+* **[Usage](https://docs.timber.io/setup/languages/python#usage)**
+* **[Guides](https://docs.timber.io/setup/languages/python#guides)**
+* **[Integrations](https://docs.timber.io/setup/languages/python/integrations)**
+* **[Performance](https://docs.timber.io/setup/languages/python#performance)**
 
-# Usage
+---
 
-### Basic Logging
-
-`timber` provides a `TimberHandler` that works with the built-in `logging` library. Just like any other handler,
-all that you need to do to set it up is add it to a logger:
-
-```python
-import logging
-import timber
-
-logger = logging.getLogger(__name__)
-
-timber_handler = timber.TimberHandler(api_key='...')
-logger.addHandler(timber_handler)
-```
-
-Then, make logging calls just like usual:
-
-```python
-logger.debug('Debug message')
-logger.info('Info message')
-logger.warning('Warning message')
-logger.critical('Critical message')
-logger.error('Error message')
-```
-
-### Logging Events (structured data)
-
-Log structured data by providing named events as part of the `extra` parameter to any logging call:
-
-```python
-logger.debug('Debug message', extra={
-  'payment_rejected': {
-    'customer_id': 'abcd1234',
-    'amount': 1000,
-    'reason': 'Card Expired',
-  }
-})
-```
-
-Any top-level `dict` on the `extra` argument will be sent as an event to the Timber console. All other types will be ignored.
-
-### Setting Context
-
-Add shared structured data across multiple logging statements:
-
-```python
-with timber.context(job={'id': 123}):
-  logger.info('Background job execution started')
-  # ... code here
-  logger.info('Background job execution completed')
-```
-
-Contexts nest and merge naturally:
-
-```python
-with timber.context(job={'id': 123, 'count': 1}):
-  # Sends a context {'job': {'id': 123, 'count': 1}}
-  logger.info('Background job execution started')
-  # ... code here
-  with timber.context(job={'count': 2}):
-    # Sends a context {'job': {'id': 123, 'count': 2}}
-    logger.info('Background job in progress')
-  # ... code here
-  # Sends a context {'job': {'id': 123, 'count': 1}}
-  logger.info('Background job execution completed')
-```
-
-# Configuration
-
-The `TimberHandler` takes a variety of parameters that allow for fine-grained control over its behavior.
-
-### `level`
-Like any other `logger.Handler`, the `TimberHandler` can be configured to only respond to log events of a specific level:
-
-```python
-# Only respond to events as least as important as `warning`
-timber_handler = timber.TimberHandler(api_key='...', level=logging.WARNING)
-```
-
-### `buffer_capacity` and `flush_interval`
-Timber buffers log events and sends them in the background for maximum performance. All outstanding log events are sent when the buffer is full or a certain amount of time has passed since any events were sent. To control the size of the buffer, pass the `buffer_capacity` argument:
-
-```python
-# Never allow more than 50 outstanding log events
-timber_handler = timber.TimberHandler(api_key='...', buffer_capacity=50)
-```
-
-To control the maximum amount of time between buffer flushes, pass the `flush_interval` argument:
-
-```python
-# Send any outstanding log events at most every 60 seconds
-timber_handler = timber.TimberHandler(api_key='...', flush_interval=60)
-```
-
-### `raise_exceptions`
-Logging should never break your application, which is why the `TimberHandler` suppresses all internal exceptions by default. To change this behavior:
-
-```python
-# Allow exceptions from internal log handling to propagate to the application,
-# instead of suppressing them.
-timber_handler = timber.TimberHandler(api_key='...', raise_exceptions=True)
-```
-
-### `drop_extra_events`
-As soon as the internal log event buffer is full, Timber flushes all of the events to the server, but while that occurs any incoming log events are dropped by default. To make your application block in this case to ensure that all log statements are sent to Timber:
-
-```python
-# Make log statements block until the internal log event buffer is no longer full.
-timber_handler = timber.TimberHandler(api_key='...', drop_extra_events=False)
-```
-
-### `context`
-By default all `TimberHandler` instances use the same context object (`timber.context`), but if you'd like
-to use multiple loggers and multiple handlers, each with a different context, it is possible to explicitly
-create and pass your own:
-
-```python
-import logging
-import timber
-
-logger = logging.getLogger(__name__)
-
-context = timber.TimberContext()
-timber_handler = timber.TimberHandler(api_key='...', context=context)
-logger.addHandler(timber_handler)
-
-with context(job={'id': 123}):
-  logger.critical('Background job execution started')
-  # ... code here
-  logger.critical('Background job execution completed')
-```
-
-# Testing
-
-1. Install the packages required for development and testing:
-
-```bash
-pip install -r requirements.txt
-pip install -r test-requirements.txt
-```
-
-2. Run the tests:
-
-```bash
-nosetests
-```
-
-To see test coverage, run the following and then open `./htmlcov/index.html` in your browser:
-
-```bash
-nosetests --with-coverage --cover-branches --cover-package=timber tests
-coverage html --include='timber*'
-```
+<p align="center">
+<a href="https://timber.io">Timber</a> &bull;
+<a href="https://docs.timber.io">Docs</a> &bull;
+<a href="https://timber.io/pricing">Pricing</a> &bull;
+<a href="https://timber.io/terms">Security</a> &bull;
+<a href="https://timber.io/privacy">Compliance</a>
+</p>

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,21 @@
+# Testing
+
+1. Install the packages required for development and testing:
+
+```bash
+pip install -r requirements.txt
+pip install -r test-requirements.txt
+```
+
+2. Run the tests:
+
+```bash
+nosetests
+```
+
+To see test coverage, run the following and then open `./htmlcov/index.html` in your browser:
+
+```bash
+nosetests --with-coverage --cover-branches --cover-package=timber tests
+coverage html --include='timber*'
+```

--- a/tests/test_flusher.py
+++ b/tests/test_flusher.py
@@ -12,14 +12,15 @@ from timber.uploader import Uploader
 
 
 class TestFlushWorker(unittest2.TestCase):
-    endpoint = 'https://timber.io/test/endpoint'
+    host = 'https://timber.io'
     api_key = 'dummy_api_key'
+    source_id = 'dummy_source_id'
     buffer_capacity = 5
     flush_interval = 2
 
     def _setup_worker(self, uploader=None):
         pipe = queue.Queue(maxsize=self.buffer_capacity)
-        uploader = uploader or Uploader(self.api_key, self.endpoint)
+        uploader = uploader or Uploader(self.api_key, self.source_id, self.host)
         fw = FlushWorker(uploader, pipe, self.buffer_capacity, self.flush_interval)
         return pipe, uploader, fw
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -11,13 +11,14 @@ from timber.handler import TimberHandler
 
 class TestTimberHandler(unittest2.TestCase):
     api_key = 'dummy_api_key'
-    endpoint = 'dummy_endpoint'
+    source_id = 'source_id'
+    host = 'dummy_host'
 
     @mock.patch('timber.handler.FlushWorker')
     def test_handler_creates_uploader_from_args(self, MockWorker):
-        handler = TimberHandler(api_key=self.api_key, endpoint=self.endpoint)
+        handler = TimberHandler(api_key=self.api_key, source_id=self.source_id, host=self.host)
         self.assertEqual(handler.uploader.api_key, self.api_key)
-        self.assertEqual(handler.uploader.endpoint, self.endpoint)
+        self.assertEqual(handler.uploader.host, self.host)
 
     @mock.patch('timber.handler.FlushWorker')
     def test_handler_creates_pipe_from_args(self, MockWorker):
@@ -25,6 +26,7 @@ class TestTimberHandler(unittest2.TestCase):
         flush_interval = 1
         handler = TimberHandler(
             api_key=self.api_key,
+            source_id=self.source_id,
             buffer_capacity=buffer_capacity,
             flush_interval=flush_interval
         )
@@ -34,7 +36,7 @@ class TestTimberHandler(unittest2.TestCase):
     def test_handler_creates_and_starts_worker_from_args(self, MockWorker):
         buffer_capacity = 9
         flush_interval = 9
-        handler = TimberHandler(api_key=self.api_key, buffer_capacity=buffer_capacity, flush_interval=flush_interval)
+        handler = TimberHandler(api_key=self.api_key, source_id=self.source_id, buffer_capacity=buffer_capacity, flush_interval=flush_interval)
         MockWorker.assert_called_with(
             handler.uploader,
             handler.pipe,
@@ -45,7 +47,7 @@ class TestTimberHandler(unittest2.TestCase):
 
     @mock.patch('timber.handler.FlushWorker')
     def test_emit_starts_thread_if_not_alive(self, MockWorker):
-        handler = TimberHandler(api_key=self.api_key)
+        handler = TimberHandler(api_key=self.api_key, source_id=self.source_id)
         self.assertTrue(handler.flush_thread.start.call_count, 1)
         handler.flush_thread.is_alive = mock.Mock(return_value=False)
 
@@ -61,6 +63,7 @@ class TestTimberHandler(unittest2.TestCase):
         buffer_capacity = 1
         handler = TimberHandler(
             api_key=self.api_key,
+            source_id=self.source_id,
             buffer_capacity=buffer_capacity,
             drop_extra_events=True
         )
@@ -79,6 +82,7 @@ class TestTimberHandler(unittest2.TestCase):
         buffer_capacity = 1
         handler = TimberHandler(
             api_key=self.api_key,
+            source_id=self.source_id,
             buffer_capacity=buffer_capacity,
             drop_extra_events=False
         )
@@ -110,6 +114,7 @@ class TestTimberHandler(unittest2.TestCase):
         buffer_capacity = 1
         handler = TimberHandler(
             api_key=self.api_key,
+            source_id=self.source_id,
             buffer_capacity=buffer_capacity,
             raise_exceptions=True
         )

--- a/tests/test_log_entry.py
+++ b/tests/test_log_entry.py
@@ -7,7 +7,7 @@ import logging
 
 class TestTimberLogEntry(unittest2.TestCase):
     def test_create_log_entry(self):
-        handler = TimberHandler(api_key="some-api-key")
+        handler = TimberHandler(api_key="some-api-key", source_id="some-source-id")
         log_record = logging.LogRecord("timber-test", 20, "/some/path", 10, "Some log message", [], None)
         log_entry = create_log_entry(handler, log_record)
         self.assertTrue(log_entry['level'] == 'info')

--- a/tests/test_uploader.py
+++ b/tests/test_uploader.py
@@ -8,7 +8,8 @@ from timber.uploader import Uploader
 
 
 class TestUploader(unittest2.TestCase):
-    endpoint = 'https://timber.io/test/endpoint'
+    host = 'https://timber.io'
+    source_id = 'dummy_source_id'
     api_key = 'dummy_api_key'
     frame = [1, 2, 3]
 
@@ -16,7 +17,7 @@ class TestUploader(unittest2.TestCase):
     def test_call(self, post):
         def mock_post(endpoint, data=None, headers=None):
             # Check that the data is sent to ther correct endpoint
-            self.assertEqual(endpoint, self.endpoint)
+            self.assertEqual(endpoint, self.host + '/sources/' + self.source_id + '/frames')
             # Check the content-type
             self.assertIsInstance(headers, dict)
             self.assertIn('Authorization', headers)
@@ -25,7 +26,7 @@ class TestUploader(unittest2.TestCase):
             self.assertEqual(msgpack.unpackb(data, raw=False), self.frame)
 
         post.side_effect = mock_post
-        u = Uploader(self.api_key, self.endpoint)
+        u = Uploader(self.api_key, self.source_id, self.host)
         u(self.frame)
 
         self.assertTrue(post.called)

--- a/timber/handler.py
+++ b/timber/handler.py
@@ -8,9 +8,9 @@ from .flusher import FlushWorker
 from .uploader import Uploader
 from .log_entry import create_log_entry
 
-DEFAULT_FRAME_ENDPOINT = 'https://logs.timber.io/frames'
+DEFAULT_HOST = 'https://logs.timber.io'
 DEFAULT_BUFFER_CAPACITY = 1000
-DEFAULT_FLUSH_INTERVAL = 30
+DEFAULT_FLUSH_INTERVAL = 2
 DEFAULT_RAISE_EXCEPTIONS = False
 DEFAULT_DROP_EXTRA_EVENTS = True
 DEFAULT_CONTEXT = TimberContext()
@@ -19,7 +19,8 @@ DEFAULT_CONTEXT = TimberContext()
 class TimberHandler(logging.Handler):
     def __init__(self,
                  api_key,
-                 endpoint=DEFAULT_FRAME_ENDPOINT,
+                 source_id,
+                 host=DEFAULT_HOST,
                  buffer_capacity=DEFAULT_BUFFER_CAPACITY,
                  flush_interval=DEFAULT_FLUSH_INTERVAL,
                  raise_exceptions=DEFAULT_RAISE_EXCEPTIONS,
@@ -28,10 +29,11 @@ class TimberHandler(logging.Handler):
                  level=logging.NOTSET):
         super(TimberHandler, self).__init__(level=level)
         self.api_key = api_key
-        self.endpoint = endpoint
+        self.source_id = source_id
+        self.host = host
         self.context = context
         self.pipe = queue.Queue(maxsize=buffer_capacity)
-        self.uploader = Uploader(self.api_key, self.endpoint)
+        self.uploader = Uploader(self.api_key, self.source_id, self.host)
         self.drop_extra_events = drop_extra_events
         self.buffer_capacity = buffer_capacity
         self.flush_interval = flush_interval

--- a/timber/log_entry.py
+++ b/timber/log_entry.py
@@ -2,16 +2,10 @@
 from __future__ import print_function, unicode_literals
 from datetime import datetime
 
-SCHEMA_URL = (
-    'https://raw.githubusercontent.com/'
-    'timberio/log-event-json-schema/v4.0.1/schema.json'
-)
-
 
 def create_log_entry(handler, record):
     r = record.__dict__
     entry = {}
-    entry['$schema'] = SCHEMA_URL
     entry['dt'] = datetime.utcfromtimestamp(r['created']).isoformat()
     entry['level'] = level = _levelname(r['levelname'])
     entry['severity'] = int(r['levelno'] / 10)
@@ -26,11 +20,11 @@ def create_log_entry(handler, record):
 
     # Custom context
     if handler.context.exists():
-        ctx['custom'] = handler.context.collapse()
+        ctx.update(handler.context.collapse())
 
     events = _parse_custom_events(record)
     if events:
-        entry['event'] = {'custom': events}
+        entry.update(events)
 
     return entry
 

--- a/timber/uploader.py
+++ b/timber/uploader.py
@@ -6,9 +6,10 @@ import requests
 
 
 class Uploader(object):
-    def __init__(self, api_key, endpoint):
+    def __init__(self, api_key, source_id, host):
         self.api_key = api_key
-        self.endpoint = endpoint
+        self.source_id = source_id
+        self.host = host
         auth_phrase = (
             base64
             .encodestring(api_key.encode('utf-8'))
@@ -21,5 +22,6 @@ class Uploader(object):
         }
 
     def __call__(self, frame):
+        endpoint = self.host + '/sources/' + self.source_id + '/frames'
         data = msgpack.packb(frame, use_bin_type=True)
-        return requests.post(self.endpoint, data=data, headers=self.headers)
+        return requests.post(endpoint, data=data, headers=self.headers)


### PR DESCRIPTION
This updates the Python library to follow the new Timber 2.0 changes:

1. Timber API keys are no longer source specific, instead a source ID is now required upon logger instantiation.
2. The log schema has changed, no longer requiring an `event` rootkey or a `custom` key within the `context` document.