### PR TITLE
Fix TimberHandler so that if the process where the handler is created gets forked, the child process can keep logging

### DIFF
--- a/timber/handler.py
+++ b/timber/handler.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from __future__ import print_function, unicode_literals
 import logging
+import multiprocessing
 
 from .compat import queue
 from .helpers import TimberContext
@@ -32,7 +33,7 @@ class TimberHandler(logging.Handler):
         self.source_id = source_id
         self.host = host
         self.context = context
-        self.pipe = queue.Queue(maxsize=buffer_capacity)
+        self.pipe = multiprocessing.JoinableQueue(maxsize=buffer_capacity)
         self.uploader = Uploader(self.api_key, self.source_id, self.host)
         self.drop_extra_events = drop_extra_events
         self.buffer_capacity = buffer_capacity
@@ -45,11 +46,15 @@ class TimberHandler(logging.Handler):
             self.buffer_capacity,
             self.flush_interval
         )
-        self.flush_thread.start()
+        if self._is_main_process():
+            self.flush_thread.start()
+
+    def _is_main_process(self):
+        return multiprocessing.current_process()._parent_pid == None
 
     def emit(self, record):
         try:
-            if not self.flush_thread.is_alive():
+            if self._is_main_process() and not self.flush_thread.is_alive():
                 self.flush_thread.start()
             log_entry = create_log_entry(self, record)
             try:


### PR DESCRIPTION
In essence, this patch makes the queue in the handler be a ``multiprocessing.Queue`` instead of ``queue.Queue``. This change makes all interactions safe to happen both in different processes and threads. 

Another side effect of dealing with multiple processes is the fact that the Flusher can not/should not run as a thread of each of the childs. The suggested solution only starts the flush thread if we detect the running process is the main one.

Existing tests have been adapted so that they are compatible with the ``multiprocessing.Queue`` interface which ``qsize()`` method is not implemented in all platforms.

Related to this issue I found a couple of interesting articles which support this approach:

> The second problem is that fork() doesn’t actually copy everything. In particular, one thing that fork() doesn’t copy is threads. Any threads running in the parent process do not exist in the child process.
https://codewithoutrules.com/2018/09/04/python-multiprocessing/

> Logging to a single file from multiple processes
https://docs.python.org/3/howto/logging-cookbook.html#logging-to-a-single-file-from-multiple-processes

I have tested this patch and it works-for-me™, but some better though would ideal from the maintainers.

Closes https://github.com/timberio/timber-python/issues/14